### PR TITLE
- Corrected gulpfile: it didn't use to copy HTML files, because the p…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/es2015-scss/gulpfile.js
+++ b/es2015-scss/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task("sass", function() {
 
 gulp.task("watch", ["sass", "copy", "browserify"], function() {
 	gulp.watch(config.source + "scss/**/*", ["sass"]);
-	gulp.watch([config.source + "images/**/*", ".src/*.html"], ["copy"]);
+	gulp.watch([config.source + "images/**/*", config.source + "*.html"], ["copy"]);
 	gulp.watch(config.source + "js/**/*", ["browserify"]);
 });
 


### PR DESCRIPTION
…aths started with ".src" rather than "./src"

- Added .gitignore: ignoring node_modules and build directories.